### PR TITLE
feat: auto-detect shell from command_language using split shell fields

### DIFF
--- a/examples/10_command.md
+++ b/examples/10_command.md
@@ -60,9 +60,6 @@ foo
 command:
   command: console.log("hello")
   command_language: js
-  shell:
-    - node
-    - "-e"
 -->
 ```js
 console.log("hello")
@@ -140,7 +137,7 @@ code_block: true
 -->
 ```yaml
 go:
-  shell:
+  script_shell:
     - go
     - run
   extensions:
@@ -149,8 +146,11 @@ hcl:
   extensions:
     - .hcl
 js:
-  shell:
+  script_shell:
     - node
+  command_shell:
+    - node
+    - -e
   extensions:
     - .js
 json:
@@ -160,13 +160,19 @@ md:
   extensions:
     - .md
 py:
-  shell:
+  script_shell:
     - python3
+  command_shell:
+    - python3
+    - -c
   extensions:
     - .py
 sh:
-  shell:
+  script_shell:
     - bash
+  command_shell:
+    - bash
+    - -c
   extensions:
     - .sh
     - .bash

--- a/pkg/controller/run/controller.go
+++ b/pkg/controller/run/controller.go
@@ -13,12 +13,13 @@ import (
 // Controller manages the initialization of docfresh configuration.
 // It provides methods to create configuration files with appropriate permissions.
 type Controller struct {
-	fs         afero.Fs
-	httpClient *http.Client
-	gh         GitHub
-	stderr     io.Writer
-	langs      map[string]*Language
-	environ    []string
+	fs          afero.Fs
+	httpClient  *http.Client
+	gh          GitHub
+	stderr      io.Writer
+	langs       map[string]*Language
+	langsByName map[string]*Language
+	environ     []string
 }
 
 type GitHub interface {
@@ -28,16 +29,17 @@ type GitHub interface {
 // New creates a new Controller instance with the provided filesystem and environment.
 // The filesystem is used for all file operations, allowing for easy testing with mock filesystems.
 func New(fs afero.Fs, gh GitHub) (*Controller, error) {
-	langs, err := defaultScriptLanguages()
+	langs, langsByName, err := defaultScriptLanguages()
 	if err != nil {
 		return nil, err
 	}
 	return &Controller{
-		fs:         fs,
-		httpClient: http.DefaultClient, // TODO Change
-		gh:         gh,
-		stderr:     os.Stderr,
-		langs:      langs,
-		environ:    os.Environ(),
+		fs:          fs,
+		httpClient:  http.DefaultClient, // TODO Change
+		gh:          gh,
+		stderr:      os.Stderr,
+		langs:       langs,
+		langsByName: langsByName,
+		environ:     os.Environ(),
 	}, nil
 }

--- a/pkg/controller/run/exec_command.go
+++ b/pkg/controller/run/exec_command.go
@@ -38,9 +38,26 @@ func getCommandDir(file string, command *Command) string {
 	return filepath.Join(filepath.Dir(file), command.Dir)
 }
 
-func getShell(command *Command, langs map[string]*Language) ([]string, error) {
+func shellFromLanguageName(command *Command, langsByName map[string]*Language) []string {
+	if command.CommandLanguage == "" {
+		return nil
+	}
+	lang, ok := langsByName[command.CommandLanguage]
+	if !ok {
+		return nil
+	}
+	if command.Script != "" {
+		return lang.ScriptShell
+	}
+	return lang.CommandShell
+}
+
+func getShell(command *Command, langs map[string]*Language, langsByName map[string]*Language) ([]string, error) {
 	if len(command.Shell) > 0 {
 		return command.Shell, nil
+	}
+	if shell := shellFromLanguageName(command, langsByName); len(shell) > 0 {
+		return shell, nil
 	}
 	if command.Script == "" {
 		return []string{"bash", "-c"}, nil
@@ -50,14 +67,14 @@ func getShell(command *Command, langs map[string]*Language) ([]string, error) {
 	}
 	ext := filepath.Ext(command.Script)
 	sl, ok := langs[ext]
-	if ok && sl.Shell != nil {
-		return sl.Shell, nil
+	if ok && len(sl.ScriptShell) > 0 {
+		return sl.ScriptShell, nil
 	}
 	return nil, errors.New("shell is required")
 }
 
 func (c *Controller) execCommand(ctx context.Context, logger *slog.Logger, file string, command *Command) (*TemplateInput, error) {
-	shell, err := getShell(command, c.langs)
+	shell, err := getShell(command, c.langs, c.langsByName)
 	if err != nil {
 		return nil, fmt.Errorf("get command.shell: %w", err)
 	}

--- a/pkg/controller/run/exec_command_internal_test.go
+++ b/pkg/controller/run/exec_command_internal_test.go
@@ -44,11 +44,16 @@ func TestGetCommandDir(t *testing.T) {
 	}
 }
 
-func TestGetShell(t *testing.T) {
+func TestGetShell(t *testing.T) { //nolint:funlen
 	t.Parallel()
 	langs := map[string]*Language{
-		".py": {Shell: []string{"python3"}, Language: "py"},
-		".go": {Shell: []string{"go", "run"}, Language: "go"},
+		".py": {ScriptShell: []string{"python3"}, Language: "py"},
+		".go": {ScriptShell: []string{"go", "run"}, Language: "go"},
+	}
+	langsByName := map[string]*Language{
+		"js": {ScriptShell: []string{"node"}, CommandShell: []string{"node", "-e"}, Language: "js"},
+		"py": {ScriptShell: []string{"python3"}, CommandShell: []string{"python3", "-c"}, Language: "py"},
+		"go": {ScriptShell: []string{"go", "run"}, Language: "go"},
 	}
 	tests := []struct {
 		name    string
@@ -86,11 +91,36 @@ func TestGetShell(t *testing.T) {
 			command: &Command{Script: "run.unknown", EmbedScript: true},
 			wantErr: true,
 		},
+		{
+			name:    "command_language auto-detects command shell",
+			command: &Command{Command: "console.log('hello')", CommandLanguage: "js"},
+			want:    []string{"node", "-e"},
+		},
+		{
+			name:    "command_language auto-detects script shell",
+			command: &Command{Script: "hello.js", CommandLanguage: "js"},
+			want:    []string{"node"},
+		},
+		{
+			name:    "command_language with no command shell falls back to bash -c",
+			command: &Command{Command: "main()", CommandLanguage: "go"},
+			want:    []string{"bash", "-c"},
+		},
+		{
+			name:    "command_language with no script shell falls back to bash",
+			command: &Command{Script: "run.txt", CommandLanguage: "json"},
+			want:    []string{"bash"},
+		},
+		{
+			name:    "explicit shell overrides command_language",
+			command: &Command{Shell: []string{"zsh", "-c"}, CommandLanguage: "js"},
+			want:    []string{"zsh", "-c"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := getShell(tt.command, langs)
+			got, err := getShell(tt.command, langs, langsByName)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error but got nil")

--- a/pkg/controller/run/languages.yaml
+++ b/pkg/controller/run/languages.yaml
@@ -1,5 +1,5 @@
 go:
-  shell:
+  script_shell:
     - go
     - run
   extensions:
@@ -8,8 +8,11 @@ hcl:
   extensions:
     - .hcl
 js:
-  shell:
+  script_shell:
     - node
+  command_shell:
+    - node
+    - -e
   extensions:
     - .js
 json:
@@ -19,13 +22,19 @@ md:
   extensions:
     - .md
 py:
-  shell:
+  script_shell:
     - python3
+  command_shell:
+    - python3
+    - -c
   extensions:
     - .py
 sh:
-  shell:
+  script_shell:
     - bash
+  command_shell:
+    - bash
+    - -c
   extensions:
     - .sh
     - .bash

--- a/pkg/controller/run/script.go
+++ b/pkg/controller/run/script.go
@@ -11,28 +11,34 @@ import (
 var languagesYAML []byte
 
 type ScriptLanguage struct {
-	Extensions []string
-	Shell      []string
+	Extensions   []string `yaml:"extensions"`
+	ScriptShell  []string `yaml:"script_shell"`
+	CommandShell []string `yaml:"command_shell"`
 }
 
 type Language struct {
-	Shell    []string
-	Language string
+	ScriptShell  []string
+	CommandShell []string
+	Language     string
 }
 
-func defaultScriptLanguages() (map[string]*Language, error) {
+func defaultScriptLanguages() (map[string]*Language, map[string]*Language, error) {
 	langs := map[string]*ScriptLanguage{}
 	if err := yaml.Unmarshal(languagesYAML, &langs); err != nil {
-		return nil, fmt.Errorf("unmrshal languages.yaml: %w", err)
+		return nil, nil, fmt.Errorf("unmrshal languages.yaml: %w", err)
 	}
-	ret := make(map[string]*Language, len(langs))
+	byExt := make(map[string]*Language, len(langs))
+	byName := make(map[string]*Language, len(langs))
 	for langName, lang := range langs {
+		l := &Language{
+			ScriptShell:  lang.ScriptShell,
+			CommandShell: lang.CommandShell,
+			Language:     langName,
+		}
+		byName[langName] = l
 		for _, ext := range lang.Extensions {
-			ret[ext] = &Language{
-				Shell:    lang.Shell,
-				Language: langName,
-			}
+			byExt[ext] = l
 		}
 	}
-	return ret, nil
+	return byExt, byName, nil
 }

--- a/pkg/controller/run/script_internal_test.go
+++ b/pkg/controller/run/script_internal_test.go
@@ -4,46 +4,79 @@ import (
 	"testing"
 )
 
-func TestDefaultScriptLanguages(t *testing.T) {
+func TestDefaultScriptLanguages(t *testing.T) { //nolint:gocognit,cyclop,funlen
 	t.Parallel()
-	langs, err := defaultScriptLanguages()
+	langs, langsByName, err := defaultScriptLanguages()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(langs) == 0 {
 		t.Fatal("expected non-empty languages map")
 	}
+	if len(langsByName) == 0 {
+		t.Fatal("expected non-empty langsByName map")
+	}
 
-	// Verify some known extensions from languages.yaml
-	checks := []struct {
-		ext      string
-		language string
-		hasShell bool
-	}{
-		{ext: ".go", language: "go", hasShell: true},
-		{ext: ".py", language: "py", hasShell: true},
-		{ext: ".sh", language: "sh", hasShell: true},
-		{ext: ".bash", language: "sh", hasShell: true},
-		{ext: ".js", language: "js", hasShell: true},
-		{ext: ".json", language: "json", hasShell: false},
-		{ext: ".yaml", language: "yaml", hasShell: false},
-		{ext: ".yml", language: "yaml", hasShell: false},
-		{ext: ".md", language: "md", hasShell: false},
-	}
-	for _, c := range checks {
-		lang, ok := langs[c.ext]
-		if !ok {
-			t.Errorf("expected extension %q to be present", c.ext)
-			continue
+	t.Run("by_extension", func(t *testing.T) {
+		t.Parallel()
+		checks := []struct {
+			ext            string
+			language       string
+			hasScriptShell bool
+		}{
+			{ext: ".go", language: "go", hasScriptShell: true},
+			{ext: ".py", language: "py", hasScriptShell: true},
+			{ext: ".sh", language: "sh", hasScriptShell: true},
+			{ext: ".bash", language: "sh", hasScriptShell: true},
+			{ext: ".js", language: "js", hasScriptShell: true},
+			{ext: ".json", language: "json", hasScriptShell: false},
+			{ext: ".yaml", language: "yaml", hasScriptShell: false},
+			{ext: ".yml", language: "yaml", hasScriptShell: false},
+			{ext: ".md", language: "md", hasScriptShell: false},
 		}
-		if lang.Language != c.language {
-			t.Errorf("extension %q: language = %q, want %q", c.ext, lang.Language, c.language)
+		for _, c := range checks {
+			lang, ok := langs[c.ext]
+			if !ok {
+				t.Errorf("expected extension %q to be present", c.ext)
+				continue
+			}
+			if lang.Language != c.language {
+				t.Errorf("extension %q: language = %q, want %q", c.ext, lang.Language, c.language)
+			}
+			if c.hasScriptShell && len(lang.ScriptShell) == 0 {
+				t.Errorf("extension %q: expected non-empty ScriptShell", c.ext)
+			}
+			if !c.hasScriptShell && len(lang.ScriptShell) != 0 {
+				t.Errorf("extension %q: expected empty ScriptShell, got %v", c.ext, lang.ScriptShell)
+			}
 		}
-		if c.hasShell && len(lang.Shell) == 0 {
-			t.Errorf("extension %q: expected non-empty shell", c.ext)
+	})
+
+	t.Run("by_name", func(t *testing.T) {
+		t.Parallel()
+		nameChecks := []struct {
+			name            string
+			hasScriptShell  bool
+			hasCommandShell bool
+		}{
+			{name: "js", hasScriptShell: true, hasCommandShell: true},
+			{name: "py", hasScriptShell: true, hasCommandShell: true},
+			{name: "sh", hasScriptShell: true, hasCommandShell: true},
+			{name: "go", hasScriptShell: true, hasCommandShell: false},
+			{name: "json", hasScriptShell: false, hasCommandShell: false},
 		}
-		if !c.hasShell && len(lang.Shell) != 0 {
-			t.Errorf("extension %q: expected empty shell, got %v", c.ext, lang.Shell)
+		for _, c := range nameChecks {
+			lang, ok := langsByName[c.name]
+			if !ok {
+				t.Errorf("expected language %q to be present in langsByName", c.name)
+				continue
+			}
+			if c.hasScriptShell && len(lang.ScriptShell) == 0 {
+				t.Errorf("language %q: expected non-empty ScriptShell", c.name)
+			}
+			if c.hasCommandShell && len(lang.CommandShell) == 0 {
+				t.Errorf("language %q: expected non-empty CommandShell", c.name)
+			}
 		}
-	}
+	})
 }


### PR DESCRIPTION
## Summary
- Split `Shell` field into `ScriptShell` and `CommandShell` in `Language`/`ScriptLanguage` structs to match the `languages.yaml` schema (`script_shell`/`command_shell`)
- Auto-detect shell from `command_language` when `shell` is not explicitly set — uses `CommandShell` for inline commands and `ScriptShell` for script files
- Add language-name-keyed map (`langsByName`) to `Controller` for looking up languages by name (e.g., `js`, `py`)
- Update example to demonstrate auto-detection (removed explicit `shell` from `command_language: js` example)

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -race -covermode=atomic` passes
- [x] `golangci-lint run` passes (0 issues)
- [x] `go run ./cmd/docfresh run examples/10_command.md` runs successfully with auto-detected shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)