### PR TITLE
fix: strip ANSI color codes from captured command output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v84 v84.0.0
+	github.com/mattn/go-colorable v0.1.14
 	github.com/spf13/afero v1.15.0
 	github.com/suzuki-shunsuke/gen-go-jsonschema v0.1.0
 	github.com/suzuki-shunsuke/ghtkn-go-sdk v0.2.2
@@ -35,7 +36,6 @@ require (
 	github.com/invopop/jsonschema v0.12.0 // indirect
 	github.com/lmittmann/tint v1.1.2 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/pkg/controller/run/docker_cli.go
+++ b/pkg/controller/run/docker_cli.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/mattn/go-colorable"
 )
 
 type DockerCLIEngine struct{}
@@ -67,8 +69,11 @@ func (d *DockerCLIEngine) Exec(ctx context.Context, containerID string, command 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	combinedOutput := &bytes.Buffer{}
-	cmd.Stdout = io.MultiWriter(os.Stdout, stdout, combinedOutput)
-	cmd.Stderr = io.MultiWriter(os.Stderr, stderr, combinedOutput)
+	uncolorizedStdout := colorable.NewNonColorable(stdout)
+	uncolorizedStderr := colorable.NewNonColorable(stderr)
+	uncolorizedCombinedOutput := colorable.NewNonColorable(combinedOutput)
+	cmd.Stdout = io.MultiWriter(os.Stdout, uncolorizedStdout, uncolorizedCombinedOutput)
+	cmd.Stderr = io.MultiWriter(os.Stderr, uncolorizedStderr, uncolorizedCombinedOutput)
 	fmt.Fprintln(os.Stderr, "+", command)
 	exitCode := 0
 	if err := cmd.Run(); err != nil {

--- a/pkg/controller/run/exec_command.go
+++ b/pkg/controller/run/exec_command.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/mattn/go-colorable"
 	"github.com/spf13/afero"
 )
 
@@ -106,8 +107,11 @@ func (c *Controller) execCommand(ctx context.Context, logger *slog.Logger, file 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 	combinedOutput := &bytes.Buffer{}
-	cmd.Stdout = io.MultiWriter(os.Stdout, stdout, combinedOutput)
-	cmd.Stderr = io.MultiWriter(os.Stderr, stderr, combinedOutput)
+	uncolorizedStdout := colorable.NewNonColorable(stdout)
+	uncolorizedStderr := colorable.NewNonColorable(stderr)
+	uncolorizedCombinedOutput := colorable.NewNonColorable(combinedOutput)
+	cmd.Stdout = io.MultiWriter(os.Stdout, uncolorizedStdout, uncolorizedCombinedOutput)
+	cmd.Stderr = io.MultiWriter(os.Stderr, uncolorizedStderr, uncolorizedCombinedOutput)
 	setCancel(logger, cmd, time.Duration(command.TimeoutSigkill)*time.Second)
 	cmd.Env = getEnv(command.Env, c.environ)
 	fmt.Fprintln(os.Stderr, "+", command.Command)


### PR DESCRIPTION
## Summary
- Strip ANSI escape sequences from command output captured into document buffers using `go-colorable`'s `NewNonColorable`
- Applies to both regular command execution (`execCommand`) and container command execution (`DockerCLIEngine.Exec`)
- Colors still display on the terminal; only the captured output for document embedding is cleaned

## Test plan
- [ ] Run `go vet ./...`, `go test ./...`, `golangci-lint run`
- [ ] Run docfresh against a markdown file with a command that produces colored output (e.g. `aqua i`) and verify no ANSI codes in the rendered document

🤖 Generated with [Claude Code](https://claude.com/claude-code)