### PR TITLE
feat: add hide_command option to suppress command display in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ Please see not only rendered markdowns but also raw source code because HTML com
 <!-- docfresh begin
 command:
   command: bash examples/file/create-index.sh
-template:
-  content: |
-    {{trimSuffix "\n" .Stdout}}
+  hide_command: true
 -->
 - [Embed Command Result](examples/10_command.md)
 - [Running Commands In Containers](examples/15_container.md)

--- a/examples/10_command.md
+++ b/examples/10_command.md
@@ -292,6 +292,18 @@ echo hello
 
 <!-- docfresh end -->
 
+## command.hide_command
+
+If this is true, the command isn't outputted to documents, only the command output is shown.
+
+<!-- docfresh begin
+command:
+  command: echo hello
+  hide_command: true
+-->
+hello
+<!-- docfresh end -->
+
 ## details_tag
 
 Allow wrapping output in HTML `<details>` tags so large outputs can be collapsed by default.

--- a/json-schema/comment.json
+++ b/json-schema/comment.json
@@ -112,6 +112,10 @@
         "quiet": {
           "type": "boolean",
           "description": "If this is true, the command output isn't outputted to documents."
+        },
+        "hide_command": {
+          "type": "boolean",
+          "description": "If this is true, the command isn't outputted to documents."
         }
       },
       "additionalProperties": false,

--- a/pkg/controller/run/command_template.md
+++ b/pkg/controller/run/command_template.md
@@ -1,3 +1,4 @@
+{{if not .HideCommand -}}
 {{if .Command -}}
 {{codeFence .Command}}{{.CommandLanguage | default "sh"}}
 {{trimSuffix "\n" .Command}}
@@ -12,6 +13,7 @@
 {{codeFence .Script}}
 {{- end}}
 
+{{end -}}
 {{if not .Quiet -}}
 {{if .DetailsTagSummary -}}
 <details>
@@ -28,8 +30,10 @@
 </details>
 {{- else -}}
 {{if .CodeBlock -}}
+{{if not .HideCommand -}}
 Output:
 
+{{end -}}
 {{codeFence .CombinedOutput}}{{.OutputLanguage}}
 {{trimSuffix "\n" .CombinedOutput}}
 {{codeFence .CombinedOutput}}

--- a/pkg/controller/run/exec.go
+++ b/pkg/controller/run/exec.go
@@ -50,6 +50,7 @@ func execContainerCommand(ctx context.Context, frc *fileRunContext, command *Com
 	result.OutputLanguage = command.OutputLanguage
 	result.EmbedScript = command.EmbedScript
 	result.Quiet = command.Quiet
+	result.HideCommand = command.HideCommand
 	return result, nil
 }
 

--- a/pkg/controller/run/exec_command.go
+++ b/pkg/controller/run/exec_command.go
@@ -133,6 +133,7 @@ func (c *Controller) execCommand(ctx context.Context, logger *slog.Logger, file 
 		ExitCode:        cmd.ProcessState.ExitCode(),
 		Content:         content,
 		Quiet:           command.Quiet,
+		HideCommand:     command.HideCommand,
 	}, nil
 }
 

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -232,7 +232,7 @@ func (b *BlockInput) GetCodeBlock() bool {
 		return *b.CodeBlock
 	}
 	if b.Command != nil {
-		return true
+		return !b.Command.HideCommand
 	}
 	return false
 }
@@ -343,6 +343,7 @@ type Command struct {
 	IgnoreFail      bool              `json:"ignore_fail,omitempty" yaml:"ignore_fail" jsonschema_description:"If this is true, docfresh does't fail even if command fails"`
 	EmbedScript     bool              `json:"embed_script,omitempty" yaml:"embed_script" jsonschema_description:"If this is true, the content of script is embedded into documents."`
 	Quiet           bool              `json:"quiet,omitempty" jsonschema_description:"If this is true, the command output isn't outputted to documents."`
+	HideCommand     bool              `json:"hide_command,omitempty" yaml:"hide_command" jsonschema_description:"If this is true, the command isn't outputted to documents."`
 }
 
 type PostCommand struct {
@@ -401,5 +402,6 @@ type TemplateInput struct {
 	EmbedScript       bool
 	CodeBlock         bool
 	Quiet             bool
+	HideCommand       bool
 	DetailsTagSummary string
 }


### PR DESCRIPTION
## Summary
- Add `hide_command` option to `command` config that suppresses the command itself from rendered output, showing only the command's output
- When `hide_command: true`, code block wrapping and "Output:" label are also suppressed by default (can be overridden with `code_block: true`)
- Works with both local and container command execution

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -race -covermode=atomic` passes
- [x] `golangci-lint run` passes
- [x] `go run ./cmd/docfresh run examples/10_command.md` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)