### PR TITLE
feat: rename quiet to hide_output for consistent naming

### DIFF
--- a/examples/10_command.md
+++ b/examples/10_command.md
@@ -277,14 +277,14 @@ SIGINT was sent
 ```
 <!-- docfresh end -->
 
-## command.quiet
+## command.hide_output
 
 If this is true, the command output isn't outputted to documents.
 
 <!-- docfresh begin
 command:
   command: echo hello
-  quiet: true
+  hide_output: true
 -->
 ```sh
 echo hello

--- a/examples/15_container.md
+++ b/examples/15_container.md
@@ -70,7 +70,7 @@ You can search for containers created by docfresh using these labels.
 command:
   command: |
     docker ps --filter "label=docfresh.id"
-  quiet: true
+  hide_output: true
 -->
 ```sh
 docker ps --filter "label=docfresh.id"

--- a/examples/70_post.md
+++ b/examples/70_post.md
@@ -41,7 +41,7 @@ command: |
 <!-- docfresh begin
 command:
   command: echo foo > foo.txt
-  quiet: true
+  hide_output: true
 -->
 ```sh
 echo foo > foo.txt

--- a/json-schema/comment.json
+++ b/json-schema/comment.json
@@ -109,7 +109,7 @@
           "type": "boolean",
           "description": "If this is true, the content of script is embedded into documents."
         },
-        "quiet": {
+        "hide_output": {
           "type": "boolean",
           "description": "If this is true, the command output isn't outputted to documents."
         },

--- a/pkg/controller/run/command_template.md
+++ b/pkg/controller/run/command_template.md
@@ -14,7 +14,7 @@
 {{- end}}
 
 {{end -}}
-{{if not .Quiet -}}
+{{if not .HideOutput -}}
 {{if .DetailsTagSummary -}}
 <details>
 <summary>{{.DetailsTagSummary}}</summary>

--- a/pkg/controller/run/exec.go
+++ b/pkg/controller/run/exec.go
@@ -49,7 +49,7 @@ func execContainerCommand(ctx context.Context, frc *fileRunContext, command *Com
 	result.CommandLanguage = command.CommandLanguage
 	result.OutputLanguage = command.OutputLanguage
 	result.EmbedScript = command.EmbedScript
-	result.Quiet = command.Quiet
+	result.HideOutput = command.HideOutput
 	result.HideCommand = command.HideCommand
 	return result, nil
 }

--- a/pkg/controller/run/exec_command.go
+++ b/pkg/controller/run/exec_command.go
@@ -132,7 +132,7 @@ func (c *Controller) execCommand(ctx context.Context, logger *slog.Logger, file 
 		CombinedOutput:  combinedOutput.String(),
 		ExitCode:        cmd.ProcessState.ExitCode(),
 		Content:         content,
-		Quiet:           command.Quiet,
+		HideOutput:      command.HideOutput,
 		HideCommand:     command.HideCommand,
 	}, nil
 }

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -342,7 +342,7 @@ type Command struct {
 	Container       *ContainerRef     `json:"container,omitempty" yaml:"container" jsonschema_description:"Run the command inside a container. Specify the container ID defined in a docfresh container block"`
 	IgnoreFail      bool              `json:"ignore_fail,omitempty" yaml:"ignore_fail" jsonschema_description:"If this is true, docfresh does't fail even if command fails"`
 	EmbedScript     bool              `json:"embed_script,omitempty" yaml:"embed_script" jsonschema_description:"If this is true, the content of script is embedded into documents."`
-	Quiet           bool              `json:"quiet,omitempty" jsonschema_description:"If this is true, the command output isn't outputted to documents."`
+	HideOutput      bool              `json:"hide_output,omitempty" yaml:"hide_output" jsonschema_description:"If this is true, the command output isn't outputted to documents."`
 	HideCommand     bool              `json:"hide_command,omitempty" yaml:"hide_command" jsonschema_description:"If this is true, the command isn't outputted to documents."`
 }
 
@@ -401,7 +401,7 @@ type TemplateInput struct {
 	//
 	EmbedScript       bool
 	CodeBlock         bool
-	Quiet             bool
+	HideOutput        bool
 	HideCommand       bool
 	DetailsTagSummary string
 }


### PR DESCRIPTION
## ⚠️ Breaking Changes

`.command.quiet` is renamed to `.command.hide_output`.

Before:

```md
<!-- docfresh begin
command:
  command: echo hello
  quiet: true
-->
```

After:

```md
<!-- docfresh begin
command:
  command: echo hello
  hide_output: true
-->
```

## Summary
- Rename `quiet` option to `hide_output` across the codebase for consistent naming with `hide_command`
- Both options now follow the `hide_*` pattern, making their relationship and purpose clearer
- Update struct fields, template, JSON schema, and examples

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./... -race -covermode=atomic` passes
- [x] `golangci-lint run` passes (0 issues)
- [x] `go run ./cmd/docfresh run` on example files succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)