### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_integration_test.yaml
+++ b/.github/workflows/workflow_call_integration_test.yaml
@@ -1,9 +1,15 @@
 ---
 name: integration test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   integration-test:
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 20
     runs-on: ${{ matrix.runs-on }}
     strategy:
@@ -17,6 +23,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: |
           go install -ldflags "-X main.version=v3.0.0-local -X main.commit=$GITHUB_SHA -X main.date=$(date +"%Y-%m-%dT%H:%M:%SZ%:z" | tr -d '+')" ./cmd/docfresh
       - run: docfresh -v

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,17 +1,28 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   integration-test:
     uses: ./.github/workflows/workflow_call_integration_test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      id-token: write
+      contents: read
 
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the Go release/test/build GitHub Actions workflows.

## Changes

- `.github/workflows/release.yaml`
  - Added `secrets:` block passing `TAKUMI_GUARD_BOT_ID` to the go-release-workflow job (ref already at v8.1.0).

- `.github/workflows/test.yaml` (entrypoint, `on: pull_request`)
  - Passed `TAKUMI_GUARD_BOT_ID` secret to the local `workflow_call_test.yaml` call and added `id-token: write` to its calling job.

- `.github/workflows/workflow_call_test.yaml` (`on: workflow_call`)
  - Bumped go-test-full-workflow `uses:` ref from `e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2` to `98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0`.
  - Declared required secret `TAKUMI_GUARD_BOT_ID` under `on.workflow_call.secrets`.
  - Passed the secret to the `test` job and the local `integration-test` call, and added `id-token: write` to both jobs.

- `.github/workflows/workflow_call_integration_test.yaml` (`on: workflow_call`)
  - Declared required secret `TAKUMI_GUARD_BOT_ID` under `on.workflow_call.secrets`.
  - Added the `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` setup step right after `actions/setup-go` and before the first module-downloading step (`go install`).
  - Added `id-token: write` and `contents: read` to the `integration-test` job permissions.

## Note

The reusable workflow bump for go-test-full-workflow crossed a MAJOR version (v5.0.2 → v6.0.0).

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository (or organization) for these workflows to function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)