### PR TITLE
fix: disable exhaustruct_v5

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - err113
     - exhaustive
     - exhaustruct
+    - exhaustruct_v5
     - godot
     - godox
     - ireturn

--- a/pkg/controller/run/parse_file.go
+++ b/pkg/controller/run/parse_file.go
@@ -76,8 +76,7 @@ func ParseFile(content string, opt *ParseOption) ([]*Block, error) { //nolint:cy
 		if containerIdx != -1 && (beginIdx == -1 || containerIdx < beginIdx) && (endIdx == -1 || containerIdx < endIdx) && (postIdx == -1 || containerIdx < postIdx) {
 			block, newPos, err := parseContainerBlock(content, pos, containerIdx, opt)
 			if err != nil {
-				var yamlErr *YAMLError
-				if errors.As(err, &yamlErr) {
+				if yamlErr, ok := errors.AsType[*YAMLError](err); ok {
 					yamlErr.DirectiveLine = lineNumber(content, pos+containerIdx)
 				}
 				return nil, err
@@ -95,8 +94,7 @@ func ParseFile(content string, opt *ParseOption) ([]*Block, error) { //nolint:cy
 		if postIdx != -1 && (beginIdx == -1 || postIdx < beginIdx) && (endIdx == -1 || postIdx < endIdx) {
 			block, newPos, err := parsePostBlock(content, pos, postIdx, opt)
 			if err != nil {
-				var yamlErr *YAMLError
-				if errors.As(err, &yamlErr) {
+				if yamlErr, ok := errors.AsType[*YAMLError](err); ok {
 					yamlErr.DirectiveLine = lineNumber(content, pos+postIdx)
 				}
 				return nil, err
@@ -134,8 +132,7 @@ func ParseFile(content string, opt *ParseOption) ([]*Block, error) { //nolint:cy
 		yamlStr = strings.TrimSpace(yamlStr)
 		var input BlockInput
 		if err := unmarshalYAML(yamlStr, &input, opt); err != nil {
-			var yamlErr *YAMLError
-			if errors.As(err, &yamlErr) {
+			if yamlErr, ok := errors.AsType[*YAMLError](err); ok {
 				yamlErr.DirectiveLine = lineNumber(content, beginStart)
 			}
 			return nil, fmt.Errorf("failed to parse YAML in begin comment: %w", err)

--- a/pkg/controller/run/run.go
+++ b/pkg/controller/run/run.go
@@ -61,8 +61,7 @@ func (c *Controller) run(ctx context.Context, logger *slog.Logger, tpls *Templat
 	}
 	blocks, err := ParseFile(string(b), parseOpt)
 	if err != nil {
-		var yamlErr *YAMLError
-		if errors.As(err, &yamlErr) {
+		if yamlErr, ok := errors.AsType[*YAMLError](err); ok {
 			fmt.Fprintf(c.stderr, "%s:%d\n", file, yamlErr.DirectiveLine)
 			fmt.Fprintln(c.stderr, yamlErr)
 			return errors.New("parse file failed")

--- a/pkg/controller/validate/validate.go
+++ b/pkg/controller/validate/validate.go
@@ -50,8 +50,7 @@ func (c *Controller) validateFile(logger *slog.Logger, file string, allowUnknown
 		return nil
 	}
 	if !allowUnknownField {
-		var yamlErr *run.YAMLError
-		if errors.As(err, &yamlErr) {
+		if yamlErr, ok := errors.AsType[*run.YAMLError](err); ok {
 			fmt.Fprintf(c.stderr, "%s:%d\n", file, yamlErr.DirectiveLine)
 			fmt.Fprintln(c.stderr, yamlErr)
 			return errors.New("parse file failed")
@@ -61,8 +60,7 @@ func (c *Controller) validateFile(logger *slog.Logger, file string, allowUnknown
 	// Try normal parse to see if the error was about unknown fields.
 	if _, normalErr := run.ParseFile(content, nil); normalErr != nil {
 		// Normal parse also fails — real YAML error.
-		var yamlErr *run.YAMLError
-		if errors.As(err, &yamlErr) {
+		if yamlErr, ok := errors.AsType[*run.YAMLError](err); ok {
 			fmt.Fprintf(c.stderr, "%s:%d\n", file, yamlErr.DirectiveLine)
 			fmt.Fprintln(c.stderr, yamlErr)
 			return errors.New("parse file failed")
@@ -70,8 +68,7 @@ func (c *Controller) validateFile(logger *slog.Logger, file string, allowUnknown
 		return fmt.Errorf("parse file: %w", err)
 	}
 	// Normal parse succeeded — the error was about unknown fields.
-	var yamlErr *run.YAMLError
-	if errors.As(err, &yamlErr) {
+	if yamlErr, ok := errors.AsType[*run.YAMLError](err); ok {
 		fmt.Fprintf(c.stderr, "%s:%d\n", file, yamlErr.DirectiveLine)
 		fmt.Fprintln(c.stderr, yamlErr)
 	} else {


### PR DESCRIPTION
Fixes the CI failure on the Renovate PR that this branches from, so that golangci-lint v2.13.0 can be merged.

golangci-lint v2.13.0 replaced `exhaustruct` with `exhaustruct_v5` (it bumped `dev.gaijin.team/go/exhaustruct` from v4 to v5). This config uses `default: all`, so the new name is enabled automatically while only the old `exhaustruct` sits in `disable`. That is why lint suddenly fails on struct literals that were fine before.

Adding `exhaustruct_v5` to `disable` keeps the linter off, the same way `wsl` and `wsl_v5` are both listed today.

Verified locally with golangci-lint v2.13.0 on three repositories. Every reported issue was `exhaustruct_v5`, and the change takes them to zero:

| repo | before | after |
|---|---|---|
| suzuki-shunsuke/ci-info | 18 issues | 0 issues |
| suzuki-shunsuke/tfcmt | 50 issues | 0 issues |
| aquaproj/aqua-registry-updater | 28 issues | 0 issues |

Base is the Renovate branch, so merging this puts the fix on it and leaves that PR to merge into the default branch as usual.

## Second commit — the remaining v2.13.0 findings

Four repositories had findings beyond `exhaustruct_v5`, so this PR carries a second commit for them. Both are v2.13.0 linter upgrades rather than anything wrong with the code:

- `modernize` gained an `errorsastype` check, which rewrites `errors.As` to the Go 1.26 `errors.AsType` generic form. `var e *T; if errors.As(err, &e) {` becomes `if e, ok := errors.AsType[*T](err); ok {`.
- `recvcheck` was bumped to v0.3.0 and no longer flags the receiver mix it used to, so the existing `//nolint:recvcheck` directives are now reported as unused by `nolintlint`.

Verified locally with golangci-lint v2.13.0: this repository reports 0 issues, and `go build ./...` and `go test ./...` pass.
